### PR TITLE
feat: support for merging DID files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JunoBuild-Didc
 
-`junobuild-didc` is a CLI tool for generating JavaScript or TypeScript content from a DID file using the [didc](https://github.com/dfinity/candid) tool.
+`junobuild-didc` is a CLI tool for generating JavaScript, TypeScript, or DID output from a Candid `.did` file using the [didc](https://github.com/dfinity/candid) tool.
 
 This utility is designed to be integrated in Juno's CLI.
 
@@ -41,6 +41,14 @@ git clone https://github.com/junobuild/didc
 cd didc
 cargo build --release
 ```
+
+Once built, the binary will be located in `target/release`. You can run it from the root directory:
+
+```bash
+./target/release/junobuild-didc --help
+```
+
+This will display the available commands and usage instructions.
 
 ### Running Tests
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use candid_parser::bindings::{javascript, typescript};
+use candid_parser::pretty;
 use candid_parser::pretty_check_file;
 use clap::Parser;
 use std::fs::{create_dir_all, write};
@@ -18,8 +19,8 @@ struct Cli {
     #[clap(short, long)]
     output: Option<PathBuf>,
 
-    /// Target output format: either `js` for JavaScript or `ts` for TypeScript.
-    #[clap(short, long, value_parser = ["js", "ts"])]
+    /// Target output format: either `js` for JavaScript, `ts` for TypeScript or `did` for Candid.
+    #[clap(short, long, value_parser = ["js", "ts", "did"])]
     target: String,
 }
 
@@ -45,14 +46,14 @@ fn write_output(output_path: &Path, content: &str) -> Result<()> {
     Ok(())
 }
 
-/// A function to generate JavaScript or TypeScript content from a DID file.
+/// A function to generate JavaScript, TypeScript, or DID content from a `.did` file.
 ///
-/// This main function serves as a wrapper around the `didc` tool, parsing the command-line arguments,
-/// processing the input `.did` file, and either printing the compiled output to stdout or writing it
-/// to a specified file based on user input.
+/// This `main` function serves as a wrapper around the `didc` tool. It parses command-line arguments,
+/// processes the input `.did` file, and outputs the result either to stdout or to a specified file,
+/// depending on user input.
 ///
-/// This function leverages `didc`'s capabilities for parsing and compiling Candid files into JavaScript
-/// or TypeScript bindings, allowing users to seamlessly generate the necessary bindings for their projects.
+/// The parser resolves any imported services and produces a single, self-contained output file
+/// — whether it's JavaScript, TypeScript, or a `.did` definition.
 ///
 /// # Errors
 ///
@@ -65,6 +66,7 @@ fn main() -> Result<()> {
     let content = match cli.target.as_str() {
         "ts" => typescript::compile(&env, &actor),
         "js" => javascript::compile(&env, &actor),
+        "did" => pretty::candid::compile(&env, &actor),
         _ => unreachable!(),
     };
 

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -70,6 +70,11 @@ fn test_ts_target() {
 }
 
 #[test]
+fn test_did_target() {
+    run_test_for_target("did", "tests/data/output.did", None);
+}
+
+#[test]
 fn test_js_target_with_output_file() {
     run_test_for_target(
         "js",
@@ -84,5 +89,14 @@ fn test_ts_target_with_output_file() {
         "ts",
         "tests/data/satellite.ts",
         Some("target/test/output.ts"),
+    );
+}
+
+#[test]
+fn test_did_target_with_output_file() {
+    run_test_for_target(
+        "did",
+        "tests/data/output.did",
+        Some("target/test/custom_output.did"),
     );
 }

--- a/tests/data/output.did
+++ b/tests/data/output.did
@@ -1,0 +1,253 @@
+type AssetEncodingNoContent = record {
+  modified : nat64;
+  sha256 : blob;
+  total_length : nat;
+};
+type AssetKey = record {
+  token : opt text;
+  collection : text;
+  owner : principal;
+  name : text;
+  description : opt text;
+  full_path : text;
+};
+type AssetNoContent = record {
+  key : AssetKey;
+  updated_at : nat64;
+  encodings : vec record { text; AssetEncodingNoContent };
+  headers : vec record { text; text };
+  created_at : nat64;
+  version : opt nat64;
+};
+type AuthenticationConfig = record {
+  internet_identity : opt AuthenticationConfigInternetIdentity;
+};
+type AuthenticationConfigInternetIdentity = record {
+  derivation_origin : opt text;
+};
+type CommitBatch = record {
+  batch_id : nat;
+  headers : vec record { text; text };
+  chunk_ids : vec nat;
+};
+type Config = record {
+  db : opt DbConfig;
+  authentication : opt AuthenticationConfig;
+  storage : StorageConfig;
+};
+type ConfigMaxMemorySize = record { stable : opt nat64; heap : opt nat64 };
+type Controller = record {
+  updated_at : nat64;
+  metadata : vec record { text; text };
+  created_at : nat64;
+  scope : ControllerScope;
+  expires_at : opt nat64;
+};
+type ControllerScope = variant { Write; Admin };
+type CustomDomain = record {
+  updated_at : nat64;
+  created_at : nat64;
+  version : opt nat64;
+  bn_id : opt text;
+};
+type DbConfig = record { max_memory_size : opt ConfigMaxMemorySize };
+type DelDoc = record { version : opt nat64 };
+type DelRule = record { version : opt nat64 };
+type DeleteControllersArgs = record { controllers : vec principal };
+type DepositCyclesArgs = record { cycles : nat; destination_id : principal };
+type Doc = record {
+  updated_at : nat64;
+  owner : principal;
+  data : blob;
+  description : opt text;
+  created_at : nat64;
+  version : opt nat64;
+};
+type HttpRequest = record {
+  url : text;
+  method : text;
+  body : blob;
+  headers : vec record { text; text };
+  certificate_version : opt nat16;
+};
+type HttpResponse = record {
+  body : blob;
+  headers : vec record { text; text };
+  streaming_strategy : opt StreamingStrategy;
+  status_code : nat16;
+};
+type InitAssetKey = record {
+  token : opt text;
+  collection : text;
+  name : text;
+  description : opt text;
+  encoding_type : opt text;
+  full_path : text;
+};
+type InitUploadResult = record { batch_id : nat };
+type ListMatcher = record {
+  key : opt text;
+  updated_at : opt TimestampMatcher;
+  description : opt text;
+  created_at : opt TimestampMatcher;
+};
+type ListOrder = record { field : ListOrderField; desc : bool };
+type ListOrderField = variant { UpdatedAt; Keys; CreatedAt };
+type ListPaginate = record { start_after : opt text; limit : opt nat64 };
+type ListParams = record {
+  order : opt ListOrder;
+  owner : opt principal;
+  matcher : opt ListMatcher;
+  paginate : opt ListPaginate;
+};
+type ListResults = record {
+  matches_pages : opt nat64;
+  matches_length : nat64;
+  items_page : opt nat64;
+  items : vec record { text; AssetNoContent };
+  items_length : nat64;
+};
+type ListResults_1 = record {
+  matches_pages : opt nat64;
+  matches_length : nat64;
+  items_page : opt nat64;
+  items : vec record { text; Doc };
+  items_length : nat64;
+};
+type Memory = variant { Heap; Stable };
+type MemorySize = record { stable : nat64; heap : nat64 };
+type Permission = variant { Controllers; Private; Public; Managed };
+type Rule = record {
+  max_capacity : opt nat32;
+  memory : opt Memory;
+  updated_at : nat64;
+  max_size : opt nat;
+  read : Permission;
+  created_at : nat64;
+  version : opt nat64;
+  mutable_permissions : opt bool;
+  write : Permission;
+};
+type RulesType = variant { Db; Storage };
+type SetController = record {
+  metadata : vec record { text; text };
+  scope : ControllerScope;
+  expires_at : opt nat64;
+};
+type SetControllersArgs = record {
+  controller : SetController;
+  controllers : vec principal;
+};
+type SetDoc = record {
+  data : blob;
+  description : opt text;
+  version : opt nat64;
+};
+type SetRule = record {
+  max_capacity : opt nat32;
+  memory : opt Memory;
+  max_size : opt nat;
+  read : Permission;
+  version : opt nat64;
+  mutable_permissions : opt bool;
+  write : Permission;
+};
+type StorageConfig = record {
+  iframe : opt StorageConfigIFrame;
+  rewrites : vec record { text; text };
+  headers : vec record { text; vec record { text; text } };
+  max_memory_size : opt ConfigMaxMemorySize;
+  raw_access : opt StorageConfigRawAccess;
+  redirects : opt vec record { text; StorageConfigRedirect };
+};
+type StorageConfigIFrame = variant { Deny; AllowAny; SameOrigin };
+type StorageConfigRawAccess = variant { Deny; Allow };
+type StorageConfigRedirect = record { status_code : nat16; location : text };
+type StreamingCallbackHttpResponse = record {
+  token : opt StreamingCallbackToken;
+  body : blob;
+};
+type StreamingCallbackToken = record {
+  memory : Memory;
+  token : opt text;
+  sha256 : opt blob;
+  headers : vec record { text; text };
+  index : nat64;
+  encoding_type : text;
+  full_path : text;
+};
+type StreamingStrategy = variant {
+  Callback : record {
+    token : StreamingCallbackToken;
+    callback : func () -> () query;
+  };
+};
+type TimestampMatcher = variant {
+  Equal : nat64;
+  Between : record { nat64; nat64 };
+  GreaterThan : nat64;
+  LessThan : nat64;
+};
+type UploadChunk = record {
+  content : blob;
+  batch_id : nat;
+  order_id : opt nat;
+};
+type UploadChunkResult = record { chunk_id : nat };
+service : {
+  build_version : () -> (text) query;
+  commit_asset_upload : (CommitBatch) -> ();
+  count_assets : (text, ListParams) -> (nat64) query;
+  count_collection_assets : (text) -> (nat64) query;
+  count_collection_docs : (text) -> (nat64) query;
+  count_docs : (text, ListParams) -> (nat64) query;
+  del_asset : (text, text) -> ();
+  del_assets : (text) -> ();
+  del_controllers : (DeleteControllersArgs) -> (
+      vec record { principal; Controller },
+    );
+  del_custom_domain : (text) -> ();
+  del_doc : (text, text, DelDoc) -> ();
+  del_docs : (text) -> ();
+  del_many_assets : (vec record { text; text }) -> ();
+  del_many_docs : (vec record { text; text; DelDoc }) -> ();
+  del_rule : (RulesType, text, DelRule) -> ();
+  deposit_cycles : (DepositCyclesArgs) -> ();
+  get_asset : (text, text) -> (opt AssetNoContent) query;
+  get_auth_config : () -> (opt AuthenticationConfig) query;
+  get_config : () -> (Config);
+  get_db_config : () -> (opt DbConfig) query;
+  get_doc : (text, text) -> (opt Doc) query;
+  get_many_assets : (vec record { text; text }) -> (
+      vec record { text; opt AssetNoContent },
+    ) query;
+  get_many_docs : (vec record { text; text }) -> (
+      vec record { text; opt Doc },
+    ) query;
+  get_storage_config : () -> (StorageConfig) query;
+  http_request : (HttpRequest) -> (HttpResponse) query;
+  http_request_streaming_callback : (StreamingCallbackToken) -> (
+      StreamingCallbackHttpResponse,
+    ) query;
+  init_asset_upload : (InitAssetKey) -> (InitUploadResult);
+  list_assets : (text, ListParams) -> (ListResults) query;
+  list_controllers : () -> (vec record { principal; Controller }) query;
+  list_custom_domains : () -> (vec record { text; CustomDomain }) query;
+  list_docs : (text, ListParams) -> (ListResults_1) query;
+  list_rules : (RulesType) -> (vec record { text; Rule }) query;
+  memory_size : () -> (MemorySize) query;
+  set_auth_config : (AuthenticationConfig) -> ();
+  set_controllers : (SetControllersArgs) -> (
+      vec record { principal; Controller },
+    );
+  set_custom_domain : (text, opt text) -> ();
+  set_db_config : (DbConfig) -> ();
+  set_doc : (text, text, SetDoc) -> (Doc);
+  set_many_docs : (vec record { text; text; SetDoc }) -> (
+      vec record { text; Doc },
+    );
+  set_rule : (RulesType, text, SetRule) -> ();
+  set_storage_config : (StorageConfig) -> ();
+  upload_asset_chunk : (UploadChunk) -> (UploadChunkResult);
+  version : () -> (text) query;
+}


### PR DESCRIPTION
## Motivation

Currently we only embed the default functions of the Satellite into the `candid:service` public section of the WASM because, I was unware of how to generate / merge DID files by resolving the imports, which we need because the serverless functions of the developers are declared in an imported did files.

## Sources

- https://forum.dfinity.org/t/ic-wasm-metadata-did-import-service/50163/6?u=peterparker
- https://github.com/dfinity/candid/issues/613#issuecomment-2960041412